### PR TITLE
allow opts.agent to override deafult of `false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ Req.prototype._send = function () {
         host: u.hostname,
         port: Number(u.port) || (protocol === 'https:' ? 443 : 80),
         path: u.path,
-        agent: false,
+        agent: this.options.agent || false,
         headers: headers,
         withCredentials: this.options.withCredentials
     };

--- a/readme.markdown
+++ b/readme.markdown
@@ -190,6 +190,7 @@ Default option values:
 * opts.auth - undefined, but is set automatically when the `uri` has an auth
 string in it such as `"http://user:passwd@host"`. `opts.auth` is of the form
 `"user:pass"`, just like `http.request()`.
+* opts.agent - `false`
 
 In https mode, you can specify options to the underlying `tls.connect()` call:
 


### PR DESCRIPTION
I'm finding myself needing to tweak agent settings so would like to be able to provide my own custom agent.