### PR TITLE
replace `Buffer()` with `new Buffer()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ Req.prototype._send = function () {
     var u = url.parse(this.uri);
     var au = u.auth || this.auth;
     if (au) {
-        headers.authorization = 'Basic ' + Buffer(au).toString('base64');
+        headers.authorization = 'Basic ' + new Buffer(au).toString('base64');
     }
     
     var protocol = u.protocol || '';

--- a/test/auth.js
+++ b/test/auth.js
@@ -6,7 +6,7 @@ var server = http.createServer(function (req, res) {
     var au = req.headers.authorization;
     if (!au) return res.end('ACCESS DENIED');
     
-    var buf = Buffer(au.replace(/^Basic\s+/, ''), 'base64');
+    var buf = new Buffer(au.replace(/^Basic\s+/, ''), 'base64');
     var s = buf.toString().split(':');
     
     if (s[0] === 'moo' && s[1] === 'hax') {

--- a/test/auth_encoded.js
+++ b/test/auth_encoded.js
@@ -6,7 +6,7 @@ var server = http.createServer(function (req, res) {
     var au = req.headers.authorization;
     if (!au) return res.end('ACCESS DENIED');
     
-    var buf = Buffer(au.replace(/^Basic\s+/, ''), 'base64');
+    var buf = new Buffer(au.replace(/^Basic\s+/, ''), 'base64');
     var s = buf.toString().split(':');
     
     if (s[0] === 'm##' && s[1] === 'h@x') {

--- a/test/auth_opt.js
+++ b/test/auth_opt.js
@@ -6,7 +6,7 @@ var server = http.createServer(function (req, res) {
     var au = req.headers.authorization;
     if (!au) return res.end('ACCESS DENIED');
     
-    var buf = Buffer(au.replace(/^Basic\s+/, ''), 'base64');
+    var buf = new Buffer(au.replace(/^Basic\s+/, ''), 'base64');
     var s = buf.toString().split(':');
     
     if (s[0] === 'moo' && s[1] === 'hax') {


### PR DESCRIPTION
Node v7 currently displays a deprecation warning when using `hyperquest`
due to the use of the `Buffer` constructor without the `new` keyword.

While the wisdom of the deprecation warning is being debated and [it may very well
be rolled back](https://github.com/nodejs/node/issues/9507#issuecomment-258987714) (at least for releases after v7.1.0), might as well add
the `new` keyword to suppress the warnings in v7.0.0 and the
soon-to-be-released v7.1.0. :-/