### PR TITLE
reduce timeout to appease node warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ Req.prototype._send = function () {
     }
     var req = iface.request(opts);
 
-    var timeout = this.options.timeout || Math.pow(2, 32) * 1000;
+    var timeout = this.options.timeout || Math.pow(2, 31) - 1;
     if (req.setTimeout) req.setTimeout(timeout);
     return req;
 };


### PR DESCRIPTION
This stops`node@9` from throwing this warning:

```
(node:40128) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
```